### PR TITLE
feat!: Use networking API and replace various Adguard misspellings

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ load_dotenv()
 
 class Config(object):
   DOMAIN_NAME = os.environ.get("DOMAIN_NAME")
-  ADGURED_DNS = os.environ.get("ADGURED_DNS")
-  ADGURED_USER = os.environ.get("ADGURED_USER")
-  ADGURED_PASS = os.environ.get("ADGURED_PASS")
+  ADGUARD_DNS = os.environ.get("ADGUARD_DNS")
+  ADGUARD_USER = os.environ.get("ADGUARD_USER")
+  ADGUARD_PASS = os.environ.get("ADGUARD_PASS")
   MODE = os.environ.get("MODE") or "PROD"

--- a/main.py
+++ b/main.py
@@ -3,7 +3,6 @@ import os
 import asyncio
 import multiprocessing
 import logging
-from time import sleep
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from kubernetes import client, config, watch
@@ -52,7 +51,7 @@ def ingress_event(netV1):
           logger.error(f'-- EVENT {event["type"]} -- Found loadbalancer IP: {lb_address}')
         except Exception as ex:
           logger.error(f'-- EVENT {event["type"]} -- Couldn\'t retrieve LoadBalancer address from record \'{missing_record}\'.')
-          sleep(10)
+          continue
 
         record = {
           "domain": missing_record,

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,14 +4,14 @@ certifi==2020.4.5.1
 chardet==3.0.4
 google-auth==1.16.1
 idna==2.9
-kubernetes==11.0.0
+kubernetes==24.2.0
 oauthlib==3.1.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 python-dateutil==2.8.1
 python-dotenv==0.14.0
 pytz==2020.1
-PyYAML==5.3.1
+PyYAML==5.4.1
 requests==2.23.0
 requests-oauthlib==1.3.0
 rsa==4.0


### PR DESCRIPTION
Changes
- Use the `networking.k8s.io/v1` API as it replaces the now-removed `extensions/v1beta1` API. (#1)
- Fix various different spellings of Adguard
- Fix DNS records not being added if rewrite list in Adguard started off as empty